### PR TITLE
Add bookmark sort as request parameter

### DIFF
--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -109,13 +109,22 @@ class BaseChargebeeStream(BaseStream):
 
         # Create params for filtering
         if self.ENTITY == 'event':
-            params = {"occurred_at[after]": bookmark_date_posix}
+            params = {
+                "occurred_at[after]": bookmark_date_posix,
+                "sort_by[asc]": "occurred_at"
+            }
             bookmark_key = 'occurred_at'
         elif self.ENTITY == 'promotional_credit':
-            params = {"created_at[after]": bookmark_date_posix}
+            params = {
+                "created_at[after]": bookmark_date_posix,
+                "sort_by[asc]": "created_at"
+            }
             bookmark_key = 'created_at'
         else:
-            params = {"updated_at[after]": bookmark_date_posix}
+            params = {
+                "updated_at[after]": bookmark_date_posix,
+                "sort_by[asc]": "updated_at"
+            }
             bookmark_key = 'updated_at'
 
         LOGGER.info("Querying {} starting at {}".format(table, bookmark_date))
@@ -138,7 +147,7 @@ class BaseChargebeeStream(BaseStream):
                         Util.addons.append(event['content']['addon'])
                     elif event['event_type'] == 'coupon_deleted':
                         Util.coupons.append(event['content']['coupon'])
-                
+
             if self.ENTITY == 'plan':
                 for plan in Util.plans:
                     to_write.append(plan)
@@ -147,13 +156,13 @@ class BaseChargebeeStream(BaseStream):
                     to_write.append(addon)
             if self.ENTITY == 'coupon':
                 for coupon in Util.coupons:
-                    to_write.append(coupon) 
+                    to_write.append(coupon)
 
             with singer.metrics.record_counter(endpoint=table) as ctr:
                 singer.write_records(table, to_write)
 
                 ctr.increment(amount=len(to_write))
-                
+
                 for item in to_write:
                     #if item.get(bookmark_key) is not None:
                     max_date = max(


### PR DESCRIPTION
## Overview

We have run into a few edge cases where a record was updated during an ongoing sync, and because of the way we paginate through result sets, the record was missed and not caught in future syncs. This small change introduces a request parameter that essentially ensures that the most recently updated records for an endpoint are always placed at the end of the offset.