### PR TITLE
Change round_off_amount in events schema to allow for negative values

### DIFF
--- a/tap_chargebee/schemas/events.json
+++ b/tap_chargebee/schemas/events.json
@@ -346,7 +346,7 @@
             },
             "round_off_amount": {
               "type": ["null", "integer"],
-              "minimum": 0
+              "minimum": -50
             },
             "deleted": {
               "type": ["null", "boolean"]
@@ -1950,13 +1950,13 @@
                     },
                     "id": {
                       "type": ["null", "string"]
-                    }, 
+                    },
                     "status": {
                       "type": ["null", "string"]
-                    }, 
+                    },
                     "amount_adjusted": {
                       "type": ["null", "integer"]
-                    }, 
+                    },
                     "amount_refunded": {
                       "type": ["null", "integer"]
                     }
@@ -3431,7 +3431,7 @@
             }
           }
         }
-        
+
       }
     }
   }


### PR DESCRIPTION
Negative round_off_amount values for credit notes do not conform to the current schema.