### PR TITLE
Update cf_company_id to allow strings

### DIFF
--- a/tap_chargebee/schemas/customers.json
+++ b/tap_chargebee/schemas/customers.json
@@ -77,7 +77,7 @@
       "type": ["null", "boolean"]
     },
     "cf_company_id": {
-      "type": ["null","integer"]
+      "type": ["null","string"]
     },
     "allow_direct_debit": {
       "type": ["null", "boolean"]


### PR DESCRIPTION
Updating to resolve sync failure in Stitch: "content.customer.cf_company_id: G-1234567 does not match {'type': ['integer', 'null']}"