### PR TITLE
Remove maxLength from payment_sources schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.2
+  * Remove `maxLength` from `payment_sources` schema to address certain integrations having IDs of greater length than specified, and make the schema more flexible as the API evolves [#44](https://github.com/singer-io/tap-chargebee/pull/44)
+
 ## 1.0.0
   * No change from 0.0.12
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-chargebee',
-      version='1.0.1',
+      version='1.0.2',
       description='Singer.io tap for extracting data from the Chargebee API',
       author='dwallace@envoy.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_chargebee/schemas/payment_sources.json
+++ b/tap_chargebee/schemas/payment_sources.json
@@ -18,14 +18,12 @@
     },
     "customer_id": {
       "type": ["null", "string"],
-      "maxLength": 50
     },
     "type": {
       "type": ["null", "string"]
     },
     "reference_id": {
       "type": ["null", "string"],
-      "maxLength": 50
     },
     "status": {
       "type": ["null", "string"]
@@ -35,15 +33,12 @@
     },
     "gateway_account_id": {
       "type": ["null", "string"],
-      "maxLength": 50
     },
     "ip_address": {
       "type": ["null", "string"],
-      "maxLength": 50
     },
     "issuing_country": {
       "type": ["null", "string"],
-      "maxLength": 50
     },
     "deleted": {
       "type": ["null", "boolean"]
@@ -59,21 +54,15 @@
       "properties": {
         "last4": {
           "type": ["null", "string"],
-          "minLength": 4,
-          "maxLength": 4
         },
         "name_on_account": {
           "type": ["null", "string"],
-          "maxLength": 300
         },
         "bank_name": {
           "type": ["null", "string"],
-          "maxLength": 100
         },
         "mandate_id": {
           "type": ["null", "string"],
-          "minLength": 5,
-          "maxLength": 17
         },
         "account_type": {
           "type": ["null", "string"]
@@ -91,11 +80,9 @@
       "properties": {
         "email": {
           "type": ["null", "string"],
-          "maxLength": 70
         },
         "agreement_id": {
           "type": ["null", "string"],
-          "maxLength": 50
         }
       }
     },
@@ -104,11 +91,9 @@
       "properties": {
         "email": {
           "type": ["null", "string"],
-          "maxLength": 70
         },
         "agremeent_id": {
           "type": ["null", "string"],
-          "maxLength": 50
         }
       }
     }


### PR DESCRIPTION
# Description of change
Schema properties like maxLength generally serve less of a purpose in an ELT sense than they would in other applications of JSON schema. In Singer, the result of including this key is usually the API making a change (e.g., expanding a field's possible width through a simple `ALTER COLUMN` statement as the product grows) causes  the tap to fail with a schema violation issue. This puts a more heavyweight burden for the tap to need an update and subsequent manual release to include the new maxLength (if it's even available through documentation).

For more stability, I'm removing the `maxLength` entries from `payment_sources` to fix the issue addressed by #27 and, to keep the scope small, am limiting it to just this stream for now.

# Manual QA steps
 - None, I'm relying on knowledge of JSON schema and how it applies.
 
# Risks
 - Low, the schemas will be more permissive after this change, so it's backwards compatible.
 
# Rollback steps
 - revert this branch, release new patch version
