### PR TITLE
Version bump to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 1.1.0
+  *  Adds support for Item Model, Multi-decimal (for Plan Model), and Account hierarchy (for Plan Model) [#56](https://github.com/singer-io/tap-chargebee/pull/56)
+  * Organized the folder structure: 
+      a. common(common schemas to both plan model and item model) 
+      b. item_model 
+      c. plan_model
+  * Introduces two new streams: ITEM_MODEL_AVAILABLE_STREAMS, PLAN_MODEL_AVAILABLE_STREAMS
 
 ## 1.0.3
   * Fix invalid JSON from #44

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-chargebee',
-      version='1.0.3',
+      version='1.1.0',
       description='Singer.io tap for extracting data from the Chargebee API',
       author='dwallace@envoy.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
## 1.1.0
  *  Adds support for Item Model, Multi-decimal (for Plan Model), and Account hierarchy (for Plan Model) [#56](https://github.com/singer-io/tap-chargebee/pull/56)
  * Organized the folder structure: 
      a. common(common schemas to both plan model and item model) 
      b. item_model 
      c. plan_model
  * Introduces two new streams: ITEM_MODEL_AVAILABLE_STREAMS, PLAN_MODEL_AVAILABLE_STREAMS
 
# Manual QA steps
-

# Risks
 - 
 
# Rollback steps
 - revert this branch
