### PR TITLE
Bump to v1.1.2, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2
+  * Fix domain name comparison bug [#67](https://github.com/singer-io/tap-chargebee/pull/67)
+
 ## 1.1.1
   * Add an error message when we get an unexpected response from the Configurations API [#62](https://github.com/singer-io/tap-chargebee/pull/62)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-chargebee',
-      version='1.1.1',
+      version='1.1.2',
       description='Singer.io tap for extracting data from the Chargebee API',
       author='dwallace@envoy.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
This is the version bump for #67 

## 1.1.2
  * Fix domain name comparison bug [#67](https://github.com/singer-io/tap-chargebee/pull/67)

# Manual QA steps
 - See #67
 
# Risks
 - See #67 
 
# Rollback steps
 - revert #67 and bump the version
