### PR TITLE
TDL-6342: Add additional fields found during testing in schema apart from API doc.

### DIFF
--- a/tap_chargebee/schemas/common/cards.json
+++ b/tap_chargebee/schemas/common/cards.json
@@ -49,6 +49,9 @@
     },
     "masked_number": {
       "type": ["null", "string"]
+    },
+    "object": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/tap_chargebee/schemas/common/credit_notes.json
+++ b/tap_chargebee/schemas/common/credit_notes.json
@@ -90,6 +90,15 @@
     "vat_number_prefix": {
       "type": ["null", "string"]
     },
+    "base_currency_code": {
+      "type": ["null", "string"]
+    },
+    "exchange_rate": {
+      "type": ["null", "number"]
+    },
+    "object": {
+      "type": ["null", "string"]
+    },
     "line_items": {
       "type": ["null", "array"],
       "items": {
@@ -162,6 +171,9 @@
           },
           "customer_id": {
             "type": ["null", "string"]
+          },
+          "object": {
+            "type": ["null", "string"]
           }
         }
       }
@@ -181,6 +193,9 @@
             "type": ["null", "string"]
           },
           "entity_id": {
+            "type": ["null", "string"]
+          },
+          "object": {
             "type": ["null", "string"]
           }
         }
@@ -205,6 +220,9 @@
           },
           "discount_amount": {
             "type": ["null", "integer"]
+          },
+          "object": {
+            "type": ["null", "string"]
           }
         }
       }

--- a/tap_chargebee/schemas/common/credit_notes.json
+++ b/tap_chargebee/schemas/common/credit_notes.json
@@ -200,6 +200,9 @@
           "coupon_id": {
             "type": ["null", "string"]
           },
+          "entity_id": {
+            "type": ["null", "string"]
+          },
           "discount_amount": {
             "type": ["null", "integer"]
           }

--- a/tap_chargebee/schemas/common/customers.json
+++ b/tap_chargebee/schemas/common/customers.json
@@ -155,6 +155,12 @@
     "vat_number_prefix": {
       "type": ["null", "string"]
     },
+    "channel": {
+      "type": ["null", "string"]
+    },
+    "mrr": {
+      "type": ["null", "integer"]
+    },
     "custom_fields": {
       "type": ["null", "string"]
     },
@@ -318,6 +324,12 @@
             "type": ["null", "integer"]
           },
           "currency_code": {
+            "type": ["null", "string"]
+          },
+          "balance_currency_code": {
+            "type": ["null", "string"]
+          },
+          "object": {
             "type": ["null", "string"]
           }
         }

--- a/tap_chargebee/schemas/common/customers.json
+++ b/tap_chargebee/schemas/common/customers.json
@@ -208,6 +208,9 @@
         },
         "validation_status": {
           "type": ["null", "string"]
+        },
+        "object": {
+          "type": ["null", "string"]
         }
       }
     },

--- a/tap_chargebee/schemas/common/gifts.json
+++ b/tap_chargebee/schemas/common/gifts.json
@@ -15,6 +15,9 @@
 		"auto_claim": {
 			"type": ["null", "boolean"]
 		},
+		"no_expiry": {
+			"type": ["null", "boolean"]
+		},
 		"claim_expiry_date": {
 			"type": ["null", "string"],
 			"format": "date-time"

--- a/tap_chargebee/schemas/common/invoices.json
+++ b/tap_chargebee/schemas/common/invoices.json
@@ -242,6 +242,9 @@
           "coupon_id": {
             "type": ["null", "string"]
           },
+          "entity_id": {
+            "type": ["null", "string"]
+          },
           "discount_amount": {
             "type": ["null", "integer"]
           }

--- a/tap_chargebee/schemas/common/invoices.json
+++ b/tap_chargebee/schemas/common/invoices.json
@@ -584,6 +584,9 @@
         },
         "validation_status": {
           "type": ["null", "string"]
+        },
+        "object": {
+          "type": ["null", "string"]
         }
       }
     },

--- a/tap_chargebee/schemas/common/invoices.json
+++ b/tap_chargebee/schemas/common/invoices.json
@@ -158,7 +158,7 @@
             "type": ["null", "integer"]
           },
           "tax_rate": {
-            "type": ["null", "integer"]
+            "type": ["null", "integer", "number"]
           },
           "amount": {
             "type": ["null", "integer"]
@@ -247,6 +247,9 @@
           },
           "discount_amount": {
             "type": ["null", "integer"]
+          },
+          "object": {
+            "type": ["null", "string"]
           }
         }
       }
@@ -280,7 +283,7 @@
             "type": ["null", "string"]
           },
           "tax_rate": {
-            "type": ["null", "integer"]
+            "type": ["null", "integer", "number"]
           },
           "is_partial_tax_applied": {
             "type": ["null", "boolean"]

--- a/tap_chargebee/schemas/common/orders.json
+++ b/tap_chargebee/schemas/common/orders.json
@@ -332,7 +332,7 @@
 	            "type": ["null", "string"]
 	          },
 	          "tax_rate": {
-	            "type": ["null", "integer"]
+	            "type": ["null", "integer", "number"]
 	          },
 	          "is_partial_tax_applied": {
 	            "type": ["null", "boolean"]

--- a/tap_chargebee/schemas/common/promotional_credits.json
+++ b/tap_chargebee/schemas/common/promotional_credits.json
@@ -38,6 +38,9 @@
     "created_at": {
     	"type": ["null", "string"],
     	"format": "date-time"
+    },
+    "object": {
+    	"type": ["null", "string"]
     }
    }
 }

--- a/tap_chargebee/schemas/common/transactions.json
+++ b/tap_chargebee/schemas/common/transactions.json
@@ -52,6 +52,12 @@
     "fraud_flag": {
       "type": ["null", "string"]
     },
+    "initiator_type": {
+      "type": ["null", "string"]
+    },
+    "three_d_secure": {
+      "type": ["null", "boolean"]
+    },
     "error_code": {
       "type": ["null", "string"]
     },
@@ -115,6 +121,9 @@
     "amount_capturable": {
       "type": ["null", "string"]
     },
+    "merchant_reference_id": {
+      "type": ["null", "string"]
+    },
     "linked_invoices": {
       "type": ["null", "array"],
       "items": {
@@ -132,7 +141,7 @@
           },
           "invoice_date": {
             "type": ["null", "string"],
-            "format": "date-times"
+            "format": "date-time"
           },
           "invoice_total": {
             "type": ["null", "integer"]

--- a/tap_chargebee/schemas/item_model/events.json
+++ b/tap_chargebee/schemas/item_model/events.json
@@ -323,6 +323,9 @@
             "contract_term_termination_fee": {
               "type": ["null", "integer"]
             },
+            "object": {
+              "type": ["null", "string"]
+            },
             "line_items": {
               "type": ["null", "array"],
               "items": {
@@ -394,6 +397,9 @@
                     "type": ["null", "string"]
                   },
                   "customer_id": {
+                    "type": ["null", "string"]
+                  },
+                  "object": {
                     "type": ["null", "string"]
                   }
                 }

--- a/tap_chargebee/schemas/item_model/events.json
+++ b/tap_chargebee/schemas/item_model/events.json
@@ -86,6 +86,14 @@
               "subscription_id": {
                 "type": ["null", "string"]
               },
+              "date_from": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "date_to": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
               "unit_amount": {
                 "type": ["null", "integer"]
               },
@@ -120,6 +128,15 @@
                 "type": ["null", "string"],
                 "format": "date-time"
               },
+              "unit_amount_in_decimal": {
+                "type": ["null", "string"]
+              },
+              "quantity_in_decimal": {
+                "type": ["null", "string"]
+              },
+              "amount_in_decimal": {
+                "type": ["null", "string"]
+              },
               "deleted": {
                 "type": ["null", "boolean"]
               },
@@ -134,11 +151,23 @@
                     "ending_unit": {
                       "type": ["null", "integer"]
                     },
-                    "quantity_used ": {
+                    "quantity_used": {
                       "type": ["null", "integer"]
                     },
                     "unit_amount ": {
                       "type": ["null", "integer"]
+                    },
+                    "starting_unit_in_decimal": {
+                      "type": ["null", "string"]
+                    },
+                    "ending_unit_in_decimal": {
+                      "type": ["null", "string"]
+                    },
+                    "quantity_used_in_decimal": {
+                      "type": ["null", "string"]
+                    },
+                    "unit_amount_in_decimal": {
+                      "type": ["null", "string"]
                     }
                   }
                 }
@@ -161,6 +190,9 @@
               "type": ["null", "string"]
             },
             "coupon_site_id": {
+              "type": ["null", "string"]
+            },
+            "coupon_set_id": {
               "type": ["null", "string"]
             },
             "coupon_set_name": {
@@ -202,6 +234,9 @@
             "id": {
               "type": ["null", "string"]
             },
+            "name": {
+              "type": ["null", "string"]
+            },
             "po_number": {
               "type": ["null", "string"]
             },
@@ -209,6 +244,9 @@
               "type": ["null", "string"]
             },
             "subscription_id": {
+              "type": ["null", "string"]
+            },
+            "invoice_id": {
               "type": ["null", "string"]
             },
             "status": {
@@ -231,6 +269,12 @@
               "type": ["null", "string"],
               "format": "date-time"
             },
+            "total_payable": {
+              "type": ["null", "integer"]
+            },
+            "charge_on_acceptance": {
+              "type": ["null", "integer"]
+            },
             "sub_total": {
               "type": ["null", "integer"]
             },
@@ -246,6 +290,9 @@
             "amount_due": {
               "type": ["null", "integer"]
             },
+            "version": {
+              "type": ["null", "integer"]
+            },
             "resource_version": {
               "type": ["null", "integer"]
             },
@@ -253,8 +300,28 @@
               "type": ["null", "string"],
               "format": "date-time"
             },
+            "vat_number_prefix": {
+              "type": ["null", "string"]
+            },
             "currency_code": {
               "type": ["null", "string"]
+            },
+            "notes": {
+              "type":["null", "array"],
+              "items":{
+                "type":["null","string"] 
+             }
+            },
+            "contract_term_start": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "contract_term_end": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "contract_term_termination_fee": {
+              "type": ["null", "integer"]
             },
             "line_items": {
               "type": ["null", "array"],
@@ -296,6 +363,15 @@
                   "tax_rate": {
                     "type": ["null", "number"]
                   },
+                  "unit_amount_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "quantity_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "amount_in_decimal": {
+                    "type": ["null", "string"]
+                  },
                   "discount_amount": {
                     "type": ["null", "integer"]
                   },
@@ -303,6 +379,9 @@
                     "type": ["null", "integer"]
                   },
                   "description": {
+                    "type": ["null", "string"]
+                  },
+                  "entity_description": {
                     "type": ["null", "string"]
                   },
                   "entity_type": {
@@ -410,6 +489,47 @@
                     "type": ["null", "string"]
                   },
                   "tax_juris_code": {
+                    "type": ["null", "string"]
+                  },
+                  "tax_amount_in_local_currency": {
+                    "type": ["null", "integer"]
+                  },
+                  "local_currency_code": {
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            },
+            "line_item_tiers": {
+              "type": ["null", "array"],
+              "items": {
+                "type": ["null", "object"],
+                "properties": {
+                  "line_item_id": {
+                    "type": ["null", "string"]
+                  },
+                  "starting_unit": {
+                    "type": ["null", "integer"]
+                  },
+                  "ending_unit": {
+                    "type": ["null", "integer"]
+                  },
+                  "quantity_used": {
+                    "type": ["null", "integer"]
+                  },
+                  "unit_amount": {
+                    "type": ["null", "integer"]
+                  },
+                  "starting_unit_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "ending_unit_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "quantity_used_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "unit_amount_in_decimal": {
                     "type": ["null", "string"]
                   }
                 }

--- a/tap_chargebee/schemas/item_model/events.json
+++ b/tap_chargebee/schemas/item_model/events.json
@@ -433,6 +433,9 @@
                   "coupon_id": {
                     "type": ["null", "string"]
                   },
+                  "entity_id": {
+                    "type": ["null", "string"]
+                  },
                   "discount_amount": {
                     "type": ["null", "integer"]
                   }

--- a/tap_chargebee/schemas/item_model/item_prices.json
+++ b/tap_chargebee/schemas/item_model/item_prices.json
@@ -196,7 +196,8 @@
       "archivable":{
          "type":[
             "null",
-            "boolean"
+            "boolean",
+            "string"
          ]
       },
       "object":{

--- a/tap_chargebee/schemas/item_model/item_prices.json
+++ b/tap_chargebee/schemas/item_model/item_prices.json
@@ -94,6 +94,12 @@
             "string"
          ]
       },
+      "trial_end_action":{
+         "type":[
+            "null",
+            "string"
+         ]
+      },
       "shipping_period":{
          "type":[
             "null",
@@ -118,6 +124,12 @@
             "integer"
          ]
       },
+      "free_quantity_in_decimal":{
+         "type":[
+            "null",
+            "string"
+         ]
+      },
       "resource_version":{
          "type":[
             "null",
@@ -132,6 +144,13 @@
          "format":"date-time"
       },
       "created_at":{
+         "type":[
+            "null",
+            "string"
+         ],
+         "format":"date-time"
+      },
+      "archived_at":{
          "type":[
             "null",
             "string"

--- a/tap_chargebee/schemas/item_model/item_prices.json
+++ b/tap_chargebee/schemas/item_model/item_prices.json
@@ -193,6 +193,12 @@
             "boolean"
          ]
       },
+      "archivable":{
+         "type":[
+            "null",
+            "boolean"
+         ]
+      },
       "object":{
          "type":[
             "null",

--- a/tap_chargebee/schemas/item_model/items.json
+++ b/tap_chargebee/schemas/item_model/items.json
@@ -132,6 +132,12 @@
             "string"
          ]
       },
+      "archivable":{
+         "type":[
+            "null",
+            "boolean"
+         ]
+      },
       "object":{
          "type":[
             "null",

--- a/tap_chargebee/schemas/item_model/items.json
+++ b/tap_chargebee/schemas/item_model/items.json
@@ -135,7 +135,8 @@
       "archivable":{
          "type":[
             "null",
-            "boolean"
+            "boolean",
+            "string"
          ]
       },
       "object":{

--- a/tap_chargebee/schemas/item_model/subscriptions.json
+++ b/tap_chargebee/schemas/item_model/subscriptions.json
@@ -332,6 +332,12 @@
             "boolean"
          ]
       },
+      "channel": {
+         "type": [
+            "null",
+            "string"
+         ]
+      },
       "custom_fields": {
          "type": [
             "null",
@@ -534,6 +540,12 @@
                      "string"
                   ],
                   "format":"date-time"
+               },
+               "object":{
+                  "type":[
+                     "null",
+                     "string"
+                  ]
                }
             }
          }

--- a/tap_chargebee/schemas/item_model/subscriptions.json
+++ b/tap_chargebee/schemas/item_model/subscriptions.json
@@ -80,6 +80,12 @@
          ],
          "format":"date-time"
       },
+      "trial_end_action":{
+         "type":[
+            "null",
+            "string"
+         ]
+      },
       "current_term_start":{
          "type":[
             "null",
@@ -204,6 +210,18 @@
             "string"
          ]
       },
+      "plan_free_quantity_in_decimal":{
+         "type":[
+            "null",
+            "string"
+         ]
+      },
+      "plan_amount_in_decimal":{
+         "type":[
+            "null",
+            "string"
+         ]
+      },
       "auto_collection":{
          "type":[
             "null",
@@ -312,6 +330,12 @@
          "type": [
             "null",
             "boolean"
+         ]
+      },
+      "custom_fields": {
+         "type": [
+            "null",
+            "string"
          ]
       },
       "subscription_items":{

--- a/tap_chargebee/schemas/plan_model/events.json
+++ b/tap_chargebee/schemas/plan_model/events.json
@@ -320,6 +320,9 @@
             "contract_term_termination_fee": {
               "type": ["null", "integer"]
             },
+            "object": {
+              "type": ["null", "string"]
+            },
             "line_items": {
               "type": ["null", "array"],
               "items": {
@@ -391,6 +394,9 @@
                     "type": ["null", "string"]
                   },
                   "customer_id": {
+                    "type": ["null", "string"]
+                  },
+                  "object": {
                     "type": ["null", "string"]
                   }
                 }

--- a/tap_chargebee/schemas/plan_model/events.json
+++ b/tap_chargebee/schemas/plan_model/events.json
@@ -83,6 +83,14 @@
               "subscription_id": {
                 "type": ["null", "string"]
               },
+              "date_from": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "date_to": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
               "unit_amount": {
                 "type": ["null", "integer"]
               },
@@ -117,6 +125,15 @@
                 "type": ["null", "string"],
                 "format": "date-time"
               },
+              "unit_amount_in_decimal": {
+                "type": ["null", "string"]
+              },
+              "quantity_in_decimal": {
+                "type": ["null", "string"]
+              },
+              "amount_in_decimal": {
+                "type": ["null", "string"]
+              },
               "deleted": {
                 "type": ["null", "boolean"]
               },
@@ -131,11 +148,23 @@
                     "ending_unit": {
                       "type": ["null", "integer"]
                     },
-                    "quantity_used ": {
+                    "quantity_used": {
                       "type": ["null", "integer"]
                     },
                     "unit_amount ": {
                       "type": ["null", "integer"]
+                    },
+                    "starting_unit_in_decimal": {
+                      "type": ["null", "string"]
+                    },
+                    "ending_unit_in_decimal": {
+                      "type": ["null", "string"]
+                    },
+                    "quantity_used_in_decimal": {
+                      "type": ["null", "string"]
+                    },
+                    "unit_amount_in_decimal": {
+                      "type": ["null", "string"]
                     }
                   }
                 }
@@ -158,6 +187,9 @@
               "type": ["null", "string"]
             },
             "coupon_site_id": {
+              "type": ["null", "string"]
+            },
+            "coupon_set_id": {
               "type": ["null", "string"]
             },
             "coupon_set_name": {
@@ -199,6 +231,9 @@
             "id": {
               "type": ["null", "string"]
             },
+            "name": {
+              "type": ["null", "string"]
+            },
             "po_number": {
               "type": ["null", "string"]
             },
@@ -206,6 +241,9 @@
               "type": ["null", "string"]
             },
             "subscription_id": {
+              "type": ["null", "string"]
+            },
+            "invoice_id": {
               "type": ["null", "string"]
             },
             "status": {
@@ -228,6 +266,12 @@
               "type": ["null", "string"],
               "format": "date-time"
             },
+            "total_payable": {
+              "type": ["null", "integer"]
+            },
+            "charge_on_acceptance": {
+              "type": ["null", "integer"]
+            },
             "sub_total": {
               "type": ["null", "integer"]
             },
@@ -243,6 +287,9 @@
             "amount_due": {
               "type": ["null", "integer"]
             },
+            "version": {
+              "type": ["null", "integer"]
+            },
             "resource_version": {
               "type": ["null", "integer"]
             },
@@ -250,8 +297,28 @@
               "type": ["null", "string"],
               "format": "date-time"
             },
+            "vat_number_prefix": {
+              "type": ["null", "string"]
+            },
             "currency_code": {
               "type": ["null", "string"]
+            },
+            "notes": {
+              "type":["null", "array"],
+              "items":{
+                "type":["null","string"] 
+             }
+            },
+            "contract_term_start": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "contract_term_end": {
+              "type": ["null", "string"],
+              "format": "date-time"
+            },
+            "contract_term_termination_fee": {
+              "type": ["null", "integer"]
             },
             "line_items": {
               "type": ["null", "array"],
@@ -293,6 +360,15 @@
                   "tax_rate": {
                     "type": ["null", "number"]
                   },
+                  "unit_amount_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "quantity_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "amount_in_decimal": {
+                    "type": ["null", "string"]
+                  },
                   "discount_amount": {
                     "type": ["null", "integer"]
                   },
@@ -300,6 +376,9 @@
                     "type": ["null", "integer"]
                   },
                   "description": {
+                    "type": ["null", "string"]
+                  },
+                  "entity_description": {
                     "type": ["null", "string"]
                   },
                   "entity_type": {
@@ -407,6 +486,47 @@
                     "type": ["null", "string"]
                   },
                   "tax_juris_code": {
+                    "type": ["null", "string"]
+                  },
+                  "tax_amount_in_local_currency": {
+                    "type": ["null", "integer"]
+                  },
+                  "local_currency_code": {
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            },
+            "line_item_tiers": {
+              "type": ["null", "array"],
+              "items": {
+                "type": ["null", "object"],
+                "properties": {
+                  "line_item_id": {
+                    "type": ["null", "string"]
+                  },
+                  "starting_unit": {
+                    "type": ["null", "integer"]
+                  },
+                  "ending_unit": {
+                    "type": ["null", "integer"]
+                  },
+                  "quantity_used": {
+                    "type": ["null", "integer"]
+                  },
+                  "unit_amount": {
+                    "type": ["null", "integer"]
+                  },
+                  "starting_unit_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "ending_unit_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "quantity_used_in_decimal": {
+                    "type": ["null", "string"]
+                  },
+                  "unit_amount_in_decimal": {
                     "type": ["null", "string"]
                   }
                 }

--- a/tap_chargebee/schemas/plan_model/plans.json
+++ b/tap_chargebee/schemas/plan_model/plans.json
@@ -154,6 +154,9 @@
     "price_in_decimal": {
       "type": ["null", "string"]
     },
+    "object": {
+      "type": ["null", "string"]
+    },
     "tiers": {
       "type": ["null", "array"],
       "items": {

--- a/tap_chargebee/schemas/plan_model/plans.json
+++ b/tap_chargebee/schemas/plan_model/plans.json
@@ -32,6 +32,9 @@
     "trial_period_unit": {
       "type": ["null", "string"]
     },
+    "trial_end_action": {
+      "type": ["null", "string"]
+    },
     "charge_model": {
       "type": ["null", "string"]
     },

--- a/tap_chargebee/schemas/plan_model/subscriptions.json
+++ b/tap_chargebee/schemas/plan_model/subscriptions.json
@@ -203,6 +203,9 @@
     "auto_close_invoices": {
       "type": ["null", "boolean"]
     },
+    "channel" : {
+      "type": ["null", "string"]
+    },
     "addons": {
       "type": ["null", "array"],
       "items": {

--- a/tap_chargebee/schemas/plan_model/subscriptions.json
+++ b/tap_chargebee/schemas/plan_model/subscriptions.json
@@ -363,6 +363,9 @@
         },
         "validation_status": {
           "type": ["null", "string"]
+        },
+        "object": {
+          "type": ["null", "string"]
         }
       }
     },

--- a/tap_chargebee/schemas/plan_model/subscriptions.json
+++ b/tap_chargebee/schemas/plan_model/subscriptions.json
@@ -43,6 +43,9 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
+    "trial_end_action": {
+      "type": ["null", "string"]
+    },
     "current_term_start": {
       "type": ["null", "string"],
       "format": "date-time"


### PR DESCRIPTION
# Description of change
- Added fields in the schema which are not present in API doc but found during testing under skipped fields.
- Added _number_ type also for field 'tax_rate' where it mentioned only integer in the schema. The data type of 'tax_rate' is double in API doc, but some of the streams using 'number' and some use' integer' in schemas.
- Added additional fields as per API doc for entities present under event.content and not part of any streams.

# Manual QA steps
 - 
 
# Risks
 - No risk
 
# Rollback steps
 - revert this branch
