### PR TITLE
TDL-16315: Implement request timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,9 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-chargebee/bin/activate
-            pip install nose
-            nosetests tests/unittests/
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_chargebee --cover-html-dir=htmlcov tests/unittests
+            coverage html
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
             pip install nose coverage
             nosetests --with-coverage --cover-erase --cover-package=tap_chargebee --cover-html-dir=htmlcov tests/unittests
             coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - run:
           name: 'Integration Tests'
           command: |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ This tap:
         "start_date": "2010-01-01T00:00:00Z",
         "api_key": "<Chargebee API Key>",
         "site": "<Chargebee Site>",
-        "include_deleted": "True|False"
+        "include_deleted": "True|False",
+        "request_timeout": 300
     }
     ```
 
@@ -53,7 +54,9 @@ This tap:
 
    The `site` parameter represents the name of your specific Chargebee site (e.g. `https://{site}.chargebee.com/api/v2/subscriptions`)
 
-   The 'include_deleted' is an optional flag to ask if you want deleted records of all streams or not. Default: true 
+   The `include_deleted` is an optional flag to ask if you want deleted records of all streams or not. Default: true 
+
+   The `request_timeout` is an optional paramater to set timeout for requests. Default: 300 seconds
 
 4. Run the Tap in Discovery Mode
 

--- a/tap_chargebee/client.py
+++ b/tap_chargebee/client.py
@@ -7,10 +7,13 @@ import simplejson
 
 from singer import utils
 from tap_framework.client import BaseClient
+from requests.exceptions import Timeout
 
 
 LOGGER = singer.get_logger()
 
+# timeout request after 300 seconds
+REQUEST_TIMEOUT = 300
 
 class Server4xxError(Exception):
     pass
@@ -51,7 +54,7 @@ class ChargebeeClient(BaseClient):
         return params
 
     @backoff.on_exception(backoff.expo,
-                          (Server4xxError, Server429Error),
+                          (Server4xxError, Server429Error, Timeout),
                           max_tries=5,
                           factor=3)
     @utils.ratelimit(100, 60)
@@ -62,13 +65,21 @@ class ChargebeeClient(BaseClient):
 
         LOGGER.info("Making {} request to {}".format(method, url))
 
+        # Set request timeout to config param `request_timeout` value.
+        config_request_timeout = self.config.get('request_timeout')
+        if config_request_timeout and float(config_request_timeout):
+            request_timeout = float(config_request_timeout)
+        else:
+            request_timeout = REQUEST_TIMEOUT # If value is 0,"0","" or not passed then set default to 300 seconds.
+
         response = requests.request(
             method,
             url,
             auth=(self.config.get("api_key"), ''),
             headers=self.get_headers(),
             params=self.get_params(params),
-            json=body)
+            json=body,
+            timeout=request_timeout)
 
         try:
             response_json = response.json()

--- a/tap_chargebee/client.py
+++ b/tap_chargebee/client.py
@@ -7,7 +7,7 @@ import simplejson
 
 from singer import utils
 from tap_framework.client import BaseClient
-from requests.exceptions import Timeout
+from requests.exceptions import Timeout, ConnectionError
 
 
 LOGGER = singer.get_logger()
@@ -54,7 +54,7 @@ class ChargebeeClient(BaseClient):
         return params
 
     @backoff.on_exception(backoff.expo,
-                          (Server4xxError, Server429Error, Timeout),
+                          (Server4xxError, Server429Error, Timeout, ConnectionError),
                           max_tries=5,
                           factor=3)
     @utils.ratelimit(100, 60)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -137,3 +137,22 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             pass
         # Verify that requests.request is called 5 times
         self.assertEqual(mocked_request.call_count, 5)
+
+
+@mock.patch("time.sleep")
+class TestConnectionErrorBackoff(unittest.TestCase):
+
+    @mock.patch("requests.request", side_effect = requests.exceptions.ConnectionError)
+    def test_request_timeout_backoff(self, mocked_request, mocked_sleep):
+        """
+            Verify make_request function is backoff for 5 times on ConnectionError exceeption
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z"}
+        chargebee_client = _client.ChargebeeClient(config)
+
+        try:
+            chargebee_client.make_request('/abc', 'GET')
+        except requests.exceptions.ConnectionError:
+            pass
+        # Verify that requests.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -135,6 +135,7 @@ class TestRequestTimeoutBackoff(unittest.TestCase):
             chargebee_client.make_request('/abc', 'GET')
         except requests.exceptions.Timeout:
             pass
+
         # Verify that requests.request is called 5 times
         self.assertEqual(mocked_request.call_count, 5)
 
@@ -154,5 +155,6 @@ class TestConnectionErrorBackoff(unittest.TestCase):
             chargebee_client.make_request('/abc', 'GET')
         except requests.exceptions.ConnectionError:
             pass
+
         # Verify that requests.request is called 5 times
         self.assertEqual(mocked_request.call_count, 5)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,139 @@
+import tap_chargebee.client as _client
+import unittest
+import requests
+from unittest import mock
+
+# Mock response object
+def get_mock_http_response(*args, **kwargs):
+    contents = '{"access_token": "test", "expires_in":100}'
+    response = requests.Response()
+    response.status_code = 200
+    response._content = contents.encode()
+    return response
+
+@mock.patch('requests.request', side_effect = get_mock_http_response)
+class TestRequestTimeoutValue(unittest.TestCase):
+
+    def test_no_request_timeout_in_config(self, mocked_request):
+        """
+            Verify that if request_timeout is not provided in config then default value is used
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z"} # No request_timeout in config
+        chargebee_client = _client.ChargebeeClient(config)
+
+        # Call make_request method which call requests.request with timeout
+        chargebee_client.make_request('/abc', 'GET')
+
+        # Verify requests.request is called with expected timeout
+        mocked_request.assert_called_with('GET', '/abc', auth=(None, ''), headers={}, json=None,
+                                          params={'limit': 100, 'include_deleted': True},
+                                          timeout=300) # Expected timeout
+
+    def test_integer_request_timeout_in_config(self, mocked_request):
+        """
+            Verify that if request_timeout is provided in config(integer value) then it should be use
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z", "request_timeout": 100} # integer timeout in config
+        chargebee_client = _client.ChargebeeClient(config)
+
+        # Call make_request method which call requests.request with timeout
+        chargebee_client.make_request('/abc', 'GET')
+
+        # Verify requests.request is called with expected timeout
+        mocked_request.assert_called_with('GET', '/abc', auth=(None, ''), headers={}, json=None,
+                                          params={'limit': 100, 'include_deleted': True},
+                                          timeout=100.0) # Expected timeout
+
+    def test_float_request_timeout_in_config(self, mocked_request):
+        """
+            Verify that if request_timeout is provided in config(float value) then it should be use
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z", "request_timeout": 100.5} # float timeout in config
+        chargebee_client = _client.ChargebeeClient(config)
+
+        # Call make_request method which call requests.request with timeout
+        chargebee_client.make_request('/abc', 'GET')
+
+        # Verify requests.request is called with expected timeout
+        mocked_request.assert_called_with('GET', '/abc', auth=(None, ''), headers={}, json=None,
+                                          params={'limit': 100, 'include_deleted': True},
+                                          timeout=100.5) # Expected timeout
+
+    def test_string_request_timeout_in_config(self, mocked_request):
+        """
+            Verify that if request_timeout is provided in config(string value) then it should be use
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z", "request_timeout": "100"} # string format timeout in config
+        chargebee_client = _client.ChargebeeClient(config)
+
+        # Call make_request method which call requests.request with timeout
+        chargebee_client.make_request('/abc', 'GET')
+
+        # Verify requests.request is called with expected timeout
+        mocked_request.assert_called_with('GET', '/abc', auth=(None, ''), headers={}, json=None,
+                                          params={'limit': 100, 'include_deleted': True},
+                                          timeout=100.0) # Expected timeout
+
+    def test_empty_string_request_timeout_in_config(self, mocked_request):
+        """
+            Verify that if request_timeout is provided in config with empty string then default value is used
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z", "request_timeout": ''} # empty string in config
+        chargebee_client = _client.ChargebeeClient(config)
+
+        # Call make_request method which call requests.request with timeout
+        chargebee_client.make_request('/abc', 'GET')
+
+        # Verify requests.request is called with expected timeout
+        mocked_request.assert_called_with('GET', '/abc', auth=(None, ''), headers={}, json=None,
+                                          params={'limit': 100, 'include_deleted': True},
+                                          timeout=300) # Expected timeout
+
+    def test_zero_request_timeout_in_config(self, mocked_request):
+        """
+            Verify that if request_timeout is provided in config with zero value then default value is used
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z", "request_timeout": 0.0} # zero value in config
+        chargebee_client = _client.ChargebeeClient(config)
+
+        # Call make_request method which call requests.request with timeout
+        chargebee_client.make_request('/abc', 'GET')
+
+        # Verify requests.request is called with expected timeout
+        mocked_request.assert_called_with('GET', '/abc', auth=(None, ''), headers={}, json=None,
+                                          params={'limit': 100, 'include_deleted': True},
+                                          timeout=300) # Expected timeout
+
+    def test_zero_string_request_timeout_in_config(self, mocked_request):
+        """
+            Verify that if request_timeout is provided in config with zero in string format then default value is used
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z", "request_timeout": '0.0'} # zero value in config
+        chargebee_client = _client.ChargebeeClient(config)
+
+        # Call make_request method which call requests.request with timeout
+        chargebee_client.make_request('/abc', 'GET')
+
+        # Verify requests.request is called with expected timeout
+        mocked_request.assert_called_with('GET', '/abc', auth=(None, ''), headers={}, json=None,
+                                          params={'limit': 100, 'include_deleted': True},
+                                          timeout=300) # Expected timeout
+
+
+@mock.patch("time.sleep")
+class TestRequestTimeoutBackoff(unittest.TestCase):
+
+    @mock.patch("requests.request", side_effect = requests.exceptions.Timeout)
+    def test_request_timeout_backoff(self, mocked_request, mocked_sleep):
+        """
+            Verify make_request function is backoff for 5 times on Timeout exceeption
+        """
+        config = {"start_date": "2017-01-01T00:00:00Z"}
+        chargebee_client = _client.ChargebeeClient(config)
+
+        try:
+            chargebee_client.make_request('/abc', 'GET')
+        except requests.exceptions.Timeout:
+            pass
+        # Verify that requests.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)


### PR DESCRIPTION
# Description of change
[TDL-16315](https://jira.talendforge.org/browse/TDL-16315): Implement request timeout
- Added request timeout for API requests with default timeout 300 seconds

**NOTE**: The CircleCI build is failing due to less data for the pagination test. Raised PR to fix pagination test #79 .

# Manual QA steps
 - Set small timeout and verified that sync calls are backing off for timeout error for each stream for both versions of Chargebee(V1 and V2).
- Provided timeout in integer, float, and string format and verified that it's used in the request.

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
