### PR TITLE
TDL-16367: Fix pagination test failure

### DIFF
--- a/tests/test_chargebee_pagination.py
+++ b/tests/test_chargebee_pagination.py
@@ -1,5 +1,7 @@
 """Test tap sync mode and metadata."""
 import re
+import os
+import requests
 
 from tap_tester import runner, menagerie, connections
 
@@ -12,6 +14,24 @@ class ChargebeePaginationTest(ChargebeeBaseTest):
     @staticmethod
     def name():
         return "tap_tester_chargebee_pagination_test"
+
+    def generate_events(self):
+        # Generate events for product catalog v1
+        url = 'https://{}.chargebee.com/api/v2/customers/cbdemo_dave'.format(os.getenv("TAP_CHARGEBEE_SITE"))
+        payload = 'first_name=Dave'
+        # Update customer two times which will generate two events
+        product_v1_api_key = os.getenv("TAP_CHARGEBEE_API_KEY")
+        requests.post(url=url, data=payload, auth=(product_v1_api_key,''))
+        requests.post(url=url, data=payload, auth=(product_v1_api_key,''))
+
+        # Generate events for product catalog v2
+        url = 'https://{}.chargebee.com/api/v2/customers/cbdemo_carol'.format(os.getenv("TAP_CHARGEBEE_SITE_V2"))
+        payload = 'first_name=Carol'
+        # Update customer two times which will generate two events
+        product_v2_api_key = os.getenv("TAP_CHARGEBEE_API_KEY_V2")
+        requests.post(url=url, data=payload, auth=(product_v2_api_key,''))
+        requests.post(url=url, data=payload, auth=(product_v2_api_key,''))
+
 
     def pagination_test_run(self):
         """
@@ -60,6 +80,8 @@ class ChargebeePaginationTest(ChargebeeBaseTest):
                     self.assertTrue(primary_keys_page_1.isdisjoint(primary_keys_page_2))
 
     def test_run(self):
+        # generate two events for both version so it will make more than 100 evenets in last 90 days
+        self.generate_events()
 
         #Pagination test for Product Catalog version 1
         self.product_catalog_v1 = True

--- a/tests/test_chargebee_pagination.py
+++ b/tests/test_chargebee_pagination.py
@@ -19,18 +19,18 @@ class ChargebeePaginationTest(ChargebeeBaseTest):
         # Generate events for product catalog v1
         url = 'https://{}.chargebee.com/api/v2/customers/cbdemo_dave'.format(os.getenv("TAP_CHARGEBEE_SITE"))
         payload = 'first_name=Dave'
-        # Update customer two times which will generate two events
+        # Update customer 20 times which will generate 20 events
         product_v1_api_key = os.getenv("TAP_CHARGEBEE_API_KEY")
-        requests.post(url=url, data=payload, auth=(product_v1_api_key,''))
-        requests.post(url=url, data=payload, auth=(product_v1_api_key,''))
+        for index in range(20):
+            requests.post(url=url, data=payload, auth=(product_v1_api_key,''))
 
         # Generate events for product catalog v2
         url = 'https://{}.chargebee.com/api/v2/customers/cbdemo_carol'.format(os.getenv("TAP_CHARGEBEE_SITE_V2"))
         payload = 'first_name=Carol'
-        # Update customer two times which will generate two events
+        # Update customer 20 times which will generate 20 events
         product_v2_api_key = os.getenv("TAP_CHARGEBEE_API_KEY_V2")
-        requests.post(url=url, data=payload, auth=(product_v2_api_key,''))
-        requests.post(url=url, data=payload, auth=(product_v2_api_key,''))
+        for index in range(20):
+            requests.post(url=url, data=payload, auth=(product_v2_api_key,''))
 
 
     def pagination_test_run(self):


### PR DESCRIPTION
# Description of change
[TDL-16367](https://jira.talendforge.org/browse/TDL-16367): Fix pagination test failure
- Added post call to update one customer 20 times which creates 20 events every time when build executes.

NOTE: The build is failing still as only 27 events return for V2 because the token used for the product version2 doesn't have permission for post-call. Need to update the token on CircleCI for the product version2 and run the build 3-4 times after that it will consistently get more than 100 events every time as we are adding 20 events every time.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
