### PR TITLE
TDL-19270: Revert back bookmarking logic

### DIFF
--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -4,6 +4,7 @@ import json
 import os
 
 import pytz
+from datetime import datetime, timedelta
 
 from .util import Util
 from dateutil.parser import parse
@@ -149,6 +150,7 @@ class BaseChargebeeStream(BaseStream):
         table = self.TABLE
         api_method = self.API_METHOD
         done = False
+        sync_interval_in_mins = 2
 
         # Attempt to get the bookmark date from the state file (if one exists and is supplied).
         LOGGER.info('Attempting to get the most recent bookmark_date for entity {}.'.format(self.ENTITY))
@@ -163,16 +165,19 @@ class BaseChargebeeStream(BaseStream):
 
         # Convert bookmarked start date to POSIX.
         bookmark_date_posix = int(bookmark_date.timestamp())
-        
+        to_date = datetime.now(pytz.utc) - timedelta(minutes=sync_interval_in_mins)
+        to_date_posix = int(to_date.timestamp())
+        sync_window = str([bookmark_date_posix, to_date_posix])
+        LOGGER.info("Sync Window {} for schema {}".format(sync_window, table))
         # Create params for filtering
         if self.ENTITY == 'event':
-            params = {"occurred_at[after]": bookmark_date_posix}
+            params = {"occurred_at[between]": sync_window}
             bookmark_key = 'occurred_at'
         elif self.ENTITY in ['promotional_credit','comment']:
-            params = {"created_at[after]": bookmark_date_posix}
+            params = {"created_at[between]": sync_window}
             bookmark_key = 'created_at'
         else:
-            params = {"updated_at[after]": bookmark_date_posix}
+            params = {"updated_at[between]": sync_window}
             bookmark_key = 'updated_at'
 
         # Add sort_by[asc] to prevent data overwrite by oldest deleted records
@@ -182,7 +187,7 @@ class BaseChargebeeStream(BaseStream):
         LOGGER.info("Querying {} starting at {}".format(table, bookmark_date))
 
         while not done:
-            max_date = bookmark_date
+            max_date = to_date
 
             response = self.client.make_request(
                 url=self.get_url(),
@@ -222,13 +227,6 @@ class BaseChargebeeStream(BaseStream):
                 singer.write_records(table, to_write)
 
                 ctr.increment(amount=len(to_write))
-                
-                for item in to_write:
-                    #if item.get(bookmark_key) is not None:
-                    max_date = max(
-                        max_date,
-                        parse(item.get(bookmark_key))
-                    )
 
             self.state = incorporate(
                 self.state, table, 'bookmark_date', max_date)

--- a/tests/unittests/test_bookmarking.py
+++ b/tests/unittests/test_bookmarking.py
@@ -1,0 +1,56 @@
+import datetime
+import pytz
+from tap_chargebee.client import ChargebeeClient
+from unittest import mock
+from tap_chargebee.streams.events import EventsStream
+import unittest
+
+# mock transfrom and return record
+def mock_transform(*args, **kwargs):
+    return args[0]
+
+@mock.patch("tap_chargebee.streams.events.EventsStream.transform_record", side_effect = mock_transform)
+@mock.patch("tap_chargebee.client.ChargebeeClient.make_request")
+@mock.patch("singer.write_records")
+@mock.patch("tap_chargebee.streams.base.save_state")
+@mock.patch('tap_chargebee.streams.base.datetime', mock.Mock(now=mock.Mock(return_value=datetime.datetime(2022, 1, 1, 5, 5, tzinfo=pytz.utc))))
+class TestBookmarking(unittest.TestCase):
+    """
+        Test cases to verify we are setting minimum (now - 2 minutes) as bookmark
+    """
+
+    config = {
+        "start_date": "2022-01-01T00:00:00Z",
+        "api_key": "test_api_key",
+        "site": "test-site",
+        "item_model": None,
+        "include_deleted": False
+    }
+    client = ChargebeeClient(config, include_deleted=False)
+    events = EventsStream(config, {}, {}, client)
+
+    def test_now_minus_2_minute_bookmark(self, mocked_save_state, mocked_records, mocked_make_request, mocked_transform_record):
+        """
+            Test case to verify we are setting (now - 2 min) as bookmark as we have max replication key greater than (now - 2 min)
+        """
+        mocked_make_request.return_value = {
+            "list": [
+                {"event": {"id": 1, "occurred_at": "2022-01-01T05:10:00.000000Z"}}]
+        }
+        self.events.sync_data()
+        args, kwargs = mocked_save_state.call_args
+        bookmark = args[0]
+        self.assertEqual(bookmark.get("bookmarks").get("events").get("bookmark_date"), "2022-01-01T05:03:00Z")
+
+    def test_max_replication_key_bookmark(self, mocked_save_state, mocked_records, mocked_make_request, mocked_transform_record):
+        """
+            Test case to verify we are setting max replication key as bookmark as we have max replication key lesser than (now - 2 min)
+        """
+        mocked_make_request.return_value = {
+            "list": [
+                {"event": {"id": 1, "occurred_at": "2022-01-01T05:02:00.000000Z"}}]
+        }
+        self.events.sync_data()
+        args, kwargs = mocked_save_state.call_args
+        bookmark = args[0]
+        self.assertEqual(bookmark.get("bookmarks").get("events").get("bookmark_date"), "2022-01-01T05:02:00Z")


### PR DESCRIPTION
# Description of change
TDL-19270: Revert back bookmarking logic
- Updated bookmark mechanism to write minimum of `max replication key` and `now - 2 minutes`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
