### PR TITLE
TDL-19489: Revert back bookmark logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##1.3.2
+  * Revert back bookmarking logic [#86](https://github.com/singer-io/tap-chargebee/pull/86)
+
 ## 1.3.1
   * Added support for Chargebee Quotes [#75](https://github.com/singer-io/tap-chargebee/pull/75)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-chargebee',
-      version='1.3.1',
+      version='1.3.2',
       description='Singer.io tap for extracting data from the Chargebee API',
       author='dwallace@envoy.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -4,6 +4,7 @@ import json
 import os
 
 import pytz
+from datetime import datetime, timedelta
 
 from .util import Util
 from dateutil.parser import parse
@@ -149,6 +150,7 @@ class BaseChargebeeStream(BaseStream):
         table = self.TABLE
         api_method = self.API_METHOD
         done = False
+        sync_interval_in_mins = 2
 
         # Attempt to get the bookmark date from the state file (if one exists and is supplied).
         LOGGER.info('Attempting to get the most recent bookmark_date for entity {}.'.format(self.ENTITY))
@@ -163,7 +165,7 @@ class BaseChargebeeStream(BaseStream):
 
         # Convert bookmarked start date to POSIX.
         bookmark_date_posix = int(bookmark_date.timestamp())
-        
+        to_date = datetime.now(pytz.utc) - timedelta(minutes=sync_interval_in_mins)
         # Create params for filtering
         if self.ENTITY == 'event':
             params = {"occurred_at[after]": bookmark_date_posix}
@@ -222,7 +224,7 @@ class BaseChargebeeStream(BaseStream):
                 singer.write_records(table, to_write)
 
                 ctr.increment(amount=len(to_write))
-                
+
                 for item in to_write:
                     #if item.get(bookmark_key) is not None:
                     max_date = max(
@@ -230,6 +232,10 @@ class BaseChargebeeStream(BaseStream):
                         parse(item.get(bookmark_key))
                     )
 
+            # update max_date with minimum of (max_replication_key) or (now - 2 minutes)
+            # this will make sure that bookmark does not go beyond (now - 2 minutes)
+            # so, no data will be missed due to API latency
+            max_date = min(max_date, to_date)
             self.state = incorporate(
                 self.state, table, 'bookmark_date', max_date)
 

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -166,15 +166,19 @@ class BaseChargebeeStream(BaseStream):
         # Convert bookmarked start date to POSIX.
         bookmark_date_posix = int(bookmark_date.timestamp())
         to_date = datetime.now(pytz.utc) - timedelta(minutes=sync_interval_in_mins)
+        to_date_posix = int(to_date.timestamp())
+        sync_window = str([bookmark_date_posix, to_date_posix])
+        LOGGER.info("Sync Window {} for schema {}".format(sync_window, table))
+
         # Create params for filtering
         if self.ENTITY == 'event':
-            params = {"occurred_at[after]": bookmark_date_posix}
+            params = {"occurred_at[between]": sync_window}
             bookmark_key = 'occurred_at'
         elif self.ENTITY in ['promotional_credit','comment']:
-            params = {"created_at[after]": bookmark_date_posix}
+            params = {"occurred_at[between]": sync_window}
             bookmark_key = 'created_at'
         else:
-            params = {"updated_at[after]": bookmark_date_posix}
+            params = {"updated_at[between]": sync_window}
             bookmark_key = 'updated_at'
 
         # Add sort_by[asc] to prevent data overwrite by oldest deleted records
@@ -184,7 +188,7 @@ class BaseChargebeeStream(BaseStream):
         LOGGER.info("Querying {} starting at {}".format(table, bookmark_date))
 
         while not done:
-            max_date = bookmark_date
+            max_date = to_date
 
             response = self.client.make_request(
                 url=self.get_url(),
@@ -225,17 +229,6 @@ class BaseChargebeeStream(BaseStream):
 
                 ctr.increment(amount=len(to_write))
 
-                for item in to_write:
-                    #if item.get(bookmark_key) is not None:
-                    max_date = max(
-                        max_date,
-                        parse(item.get(bookmark_key))
-                    )
-
-            # update max_date with minimum of (max_replication_key) or (now - 2 minutes)
-            # this will make sure that bookmark does not go beyond (now - 2 minutes)
-            # so, no data will be missed due to API latency
-            max_date = min(max_date, to_date)
             self.state = incorporate(
                 self.state, table, 'bookmark_date', max_date)
 

--- a/tests/test_chargebee_pagination.py
+++ b/tests/test_chargebee_pagination.py
@@ -1,5 +1,7 @@
 """Test tap sync mode and metadata."""
 import re
+import os
+import requests
 
 from tap_tester import runner, menagerie, connections
 
@@ -12,6 +14,24 @@ class ChargebeePaginationTest(ChargebeeBaseTest):
     @staticmethod
     def name():
         return "tap_tester_chargebee_pagination_test"
+
+    def generate_events(self):
+        # Generate events for product catalog v1
+        url = 'https://{}.chargebee.com/api/v2/customers/cbdemo_dave'.format(os.getenv("TAP_CHARGEBEE_SITE"))
+        payload = 'first_name=Dave'
+        # Update customer 20 times which will generate 20 events
+        product_v1_api_key = os.getenv("TAP_CHARGEBEE_API_KEY")
+        for index in range(20):
+            requests.post(url=url, data=payload, auth=(product_v1_api_key,''))
+
+        # Generate events for product catalog v2
+        url = 'https://{}.chargebee.com/api/v2/customers/cbdemo_carol'.format(os.getenv("TAP_CHARGEBEE_SITE_V2"))
+        payload = 'first_name=Carol'
+        # Update customer 20 times which will generate 20 events
+        product_v2_api_key = os.getenv("TAP_CHARGEBEE_API_KEY_V2")
+        for index in range(20):
+            requests.post(url=url, data=payload, auth=(product_v2_api_key,''))
+
 
     def pagination_test_run(self):
         """
@@ -60,6 +80,8 @@ class ChargebeePaginationTest(ChargebeeBaseTest):
                     self.assertTrue(primary_keys_page_1.isdisjoint(primary_keys_page_2))
 
     def test_run(self):
+        # generate two events for both version so it will make more than 100 evenets in last 90 days
+        self.generate_events()
 
         #Pagination test for Product Catalog version 1
         self.product_catalog_v1 = True

--- a/tests/unittests/test_bookmarking.py
+++ b/tests/unittests/test_bookmarking.py
@@ -44,7 +44,7 @@ class TestBookmarking(unittest.TestCase):
 
     def test_max_replication_key_bookmark(self, mocked_save_state, mocked_records, mocked_make_request, mocked_transform_record):
         """
-            Test case to verify we are setting max replication key as bookmark as we have max replication key lesser than (now - 2 min)
+            Test case to verify we are setting (now - 2 min) as bookmark when we have max replication key lesser than (now - 2 min)
         """
         mocked_make_request.return_value = {
             "list": [
@@ -53,4 +53,4 @@ class TestBookmarking(unittest.TestCase):
         self.events.sync_data()
         args, kwargs = mocked_save_state.call_args
         bookmark = args[0]
-        self.assertEqual(bookmark.get("bookmarks").get("events").get("bookmark_date"), "2022-01-01T05:02:00Z")
+        self.assertEqual(bookmark.get("bookmarks").get("events").get("bookmark_date"), "2022-01-01T05:03:00Z")

--- a/tests/unittests/test_bookmarking.py
+++ b/tests/unittests/test_bookmarking.py
@@ -1,0 +1,56 @@
+import datetime
+import pytz
+from tap_chargebee.client import ChargebeeClient
+from unittest import mock
+from tap_chargebee.streams.events import EventsStream
+import unittest
+
+# mock transfrom and return record
+def mock_transform(*args, **kwargs):
+    return args[0]
+
+@mock.patch("tap_chargebee.streams.events.EventsStream.transform_record", side_effect = mock_transform)
+@mock.patch("tap_chargebee.client.ChargebeeClient.make_request")
+@mock.patch("singer.write_records")
+@mock.patch("tap_chargebee.streams.base.save_state")
+@mock.patch('tap_chargebee.streams.base.datetime', mock.Mock(now=mock.Mock(return_value=datetime.datetime(2022, 1, 1, 5, 5, tzinfo=pytz.utc))))
+class TestBookmarking(unittest.TestCase):
+    """
+        Test cases to verify we are setting minimum (now - 2 minutes) as bookmark
+    """
+
+    config = {
+        "start_date": "2022-01-01T00:00:00Z",
+        "api_key": "test_api_key",
+        "site": "test-site",
+        "item_model": None,
+        "include_deleted": False
+    }
+    client = ChargebeeClient(config, include_deleted=False)
+    events = EventsStream(config, {}, {}, client)
+
+    def test_now_minus_2_minute_bookmark(self, mocked_save_state, mocked_records, mocked_make_request, mocked_transform_record):
+        """
+            Test case to verify we are setting (now - 2 min) as bookmark as we have max replication key greater than (now - 2 min)
+        """
+        mocked_make_request.return_value = {
+            "list": [
+                {"event": {"id": 1, "occurred_at": "2022-01-01T05:10:00.000000Z"}}]
+        }
+        self.events.sync_data()
+        args, kwargs = mocked_save_state.call_args
+        bookmark = args[0]
+        self.assertEqual(bookmark.get("bookmarks").get("events").get("bookmark_date"), "2022-01-01T05:03:00Z")
+
+    def test_max_replication_key_bookmark(self, mocked_save_state, mocked_records, mocked_make_request, mocked_transform_record):
+        """
+            Test case to verify we are setting max replication key as bookmark as we have max replication key lesser than (now - 2 min)
+        """
+        mocked_make_request.return_value = {
+            "list": [
+                {"event": {"id": 1, "occurred_at": "2022-01-01T05:02:00.000000Z"}}]
+        }
+        self.events.sync_data()
+        args, kwargs = mocked_save_state.call_args
+        bookmark = args[0]
+        self.assertEqual(bookmark.get("bookmarks").get("events").get("bookmark_date"), "2022-01-01T05:02:00Z")


### PR DESCRIPTION
# Description of change
TDL-19489: Revert back bookmark logic
- Revert the bookmark logic from PR #54.
  - Now all streams will store `now - 2 minutes` as the bookmark.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
