### PR TITLE
fix: Prevent truncating invoice lineItem taxRates

### DIFF
--- a/tap_chargebee/schemas/common/invoices.json
+++ b/tap_chargebee/schemas/common/invoices.json
@@ -165,7 +165,7 @@
             "type": ["null", "integer"]
           },
           "tax_rate": {
-            "type": ["null", "integer", "number"]
+            "type": ["null", "number"]
           },
           "amount": {
             "type": ["null", "integer"]


### PR DESCRIPTION
tax_rate can't be stored as an integer because many states allow fractional tax rates

This change makes it match `credit_notes.json` (which stores correctly as a float)

# Description of change
- update the 'tax_rate' field schema 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
