### PR TITLE
Update subscriptions schema to include manual discounts

### DIFF
--- a/tap_chargebee/schemas/item_model/subscriptions.json
+++ b/tap_chargebee/schemas/item_model/subscriptions.json
@@ -351,6 +351,146 @@
             "string"
          ]
       },
+      "discounts":{
+         "type":[
+            "null",
+            "array"
+         ],
+         "items":{
+            "type":[
+               "null",
+               "object"
+            ],
+            "properties":{
+               "id": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "invoice_name": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "type": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "percentage": {
+                  "type": [
+                     "null",
+                     "number"
+                  ]
+                },
+                "amount": {
+                  "type": [
+                     "null",
+                     "number"
+                  ]
+                },
+                "currency_code": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "duration_type": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "period": {
+                  "type": [
+                     "null",
+                     "integer"
+                  ]
+                },
+                "period_unit": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "included_in_mrr": {
+                  "type": [
+                     "null",
+                     "boolean"
+                  ]
+                },
+                "apply_on": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "item_price_id": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "created_at": {
+                  "type": [
+                     "null",
+                     "integer"
+                  ]
+                },
+                "name": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "updated_at": {
+                  "type": [
+                     "null",
+                     "integer"
+                  ]
+                },
+                "resource_version": {
+                  "type": [
+                     "null",
+                     "integer"
+                  ]
+                },
+                "applied_count": {
+                  "type": [
+                     "null",
+                     "integer"
+                  ]
+                },
+                "coupon_id": {
+                  "type": [
+                     "null",
+                     "string"
+                  ]
+                },
+                "index": {
+                  "type": [
+                     "null",
+                     "integer"
+                  ]
+                },
+                "apply_till": {
+                  "type": [
+                     "null",
+                     "integer"
+                  ]
+                },
+                "object": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+            }
+         }
+      },
       "subscription_items":{
          "type":[
             "null",


### PR DESCRIPTION
# Description of change
Currently, tap's subscription schema doesn't include manual discounts. This PR updates the subscription schema to include missing discount attributes based on [Chargebee API](https://apidocs.eu.chargebee.com/docs/api/discounts#discount_attributes).

# Manual QA steps
 - Installed locally (`python setup.py install`), configured to use our Chargebee site
 - Generated catalog (`tap-chargebee --config config.json --discover > catalog.json`), verified that it contains new attributes
 - Ran the tap (`tap-chargebee  --config config.json --catalog catalog.json`) and verified that `RECORD` documents now contain manual discounts (where applied)
 
# Risks
 None I can think of
 
# Rollback steps
 - revert this branch
