### PR TITLE
write bookmark when no records are synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0
+- Update incremental streams to write bookmarks when no data is synced #[120](https://github.com/singer-io/tap-chargebee/pull/120)
+
 ## 1.5.0
 
 - Refactored the tap #[113](https://github.com/singer-io/tap-chargebee/pull/113)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-chargebee',
-      version='1.5.0',
+      version='1.6.0',
       description='Singer.io tap for extracting data from the Chargebee API',
       author='dwallace@envoy.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -270,10 +270,8 @@ class BaseChargebeeStream:
                 # Write state after each page
                 singer.write_state(self.state)
 
-            # If no records were synced, update bookmark 
-            current_bookmark = singer.get_bookmark(
-                self.state, self.STREAM, self.REPLICATION_KEY)
-            if not current_bookmark:
+            # If no records were synced, update bookmark
+            if not replication_key_value:
                 current_time = datetime.today().strftime(DATETIME_FORMAT)
                 self.update_bookmark(current_time)
             return counter.value

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -269,4 +269,8 @@ class BaseChargebeeStream:
 
                 # Write state after each page
                 singer.write_state(self.state)
+
+            # If no records were sync, update bookmark to today
+            current_time = datetime.today().strftime(DATETIME_FORMAT)
+            self.update_bookmark(current_time)
             return counter.value

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -238,7 +238,7 @@ class BaseChargebeeStream:
         pages = self.client.get_offset_based_pages(
             self.get_url(), self.API_METHOD, self.SORT_BY, params
         )
-
+        bookmark_not_updated = True
         with metrics.record_counter(self.STREAM) as counter, Transformer(
             integer_datetime_fmt=UNIX_SECONDS_INTEGER_DATETIME_PARSING
         ) as transformer:
@@ -266,12 +266,11 @@ class BaseChargebeeStream:
                     singer.write_record(self.STREAM, transformed_record)
                     self.update_bookmark(replication_key_value)
                     counter.increment()
-
+                    bookmark_not_updated = False
                 # Write state after each page
                 singer.write_state(self.state)
 
-            # If no records were synced, update bookmark
-            if not replication_key_value:
+            if bookmark_not_updated:
                 current_time = datetime.today().strftime(DATETIME_FORMAT)
                 self.update_bookmark(current_time)
             return counter.value

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -230,6 +230,10 @@ class BaseChargebeeStream:
             last_bookmark_value, LOOKBACK_WINDOW
         )
 
+        # If no records are written use now as new bookmark
+        current_time = datetime.now(pytz.UTC).strftime(DATETIME_FORMAT)
+        bookmark_not_updated = True
+        
         # Filtering parameters
         params = {f"{self.REPLICATION_KEY}[after]": lookback_evaluated_bookmark}
 
@@ -238,7 +242,6 @@ class BaseChargebeeStream:
         pages = self.client.get_offset_based_pages(
             self.get_url(), self.API_METHOD, self.SORT_BY, params
         )
-        bookmark_not_updated = True
         with metrics.record_counter(self.STREAM) as counter, Transformer(
             integer_datetime_fmt=UNIX_SECONDS_INTEGER_DATETIME_PARSING
         ) as transformer:
@@ -271,6 +274,5 @@ class BaseChargebeeStream:
                 singer.write_state(self.state)
 
             if bookmark_not_updated:
-                current_time = datetime.today().strftime(DATETIME_FORMAT)
                 self.update_bookmark(current_time)
             return counter.value

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -270,7 +270,10 @@ class BaseChargebeeStream:
                 # Write state after each page
                 singer.write_state(self.state)
 
-            # If no records were sync, update bookmark to today
-            current_time = datetime.today().strftime(DATETIME_FORMAT)
-            self.update_bookmark(current_time)
+            # If no records were synced, update bookmark 
+            current_bookmark = singer.get_bookmark(
+                self.state, self.STREAM, self.REPLICATION_KEY)
+            if not current_bookmark:
+                current_time = datetime.today().strftime(DATETIME_FORMAT)
+                self.update_bookmark(current_time)
             return counter.value

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -233,7 +233,7 @@ class BaseChargebeeStream:
         # If no records are written use now as new bookmark
         current_time = datetime.now(pytz.UTC).strftime(DATETIME_FORMAT)
         bookmark_not_updated = True
-        
+
         # Filtering parameters
         params = {f"{self.REPLICATION_KEY}[after]": lookback_evaluated_bookmark}
 

--- a/tests/test_chargebee_all_fields.py
+++ b/tests/test_chargebee_all_fields.py
@@ -83,7 +83,6 @@ class ChargebeeAllFieldsTest(ChargebeeBaseTest):
             'entity_identifiers',
             'entity_identifier_scheme',
             'cf_people_id',
-            'invoice_notes',
             'tax_providers_fields',
             'business_entity_id',
             'created_from_ip',

--- a/tests/test_chargebee_bookmark.py
+++ b/tests/test_chargebee_bookmark.py
@@ -26,11 +26,11 @@ class ChargebeeBookmarkTest(ChargebeeBaseTest):
         for stream_name, bookmark in new_state.get("bookmarks").items():
             stream_records = [record.get('data') for record in records.get(stream_name, {}).get('messages', [])
                               if record.get('action') == 'upsert']
-            # as these streams are skipped the state file will contain the start date as bookmark
-            if stream_name in self.streams_to_skip | {'quotes'}:
-                bookmark_date = bookmark["bookmark_date"]
+            replication_key = list(self.expected_replication_keys().get(stream_name))[0]
+            if stream_records:
+                bookmark_date = self.get_max_replication_value(stream_records, replication_key)
             else:
-                bookmark_date = self.get_max_replication_value(stream_records, list(self.expected_replication_keys().get(stream_name))[0])
+                bookmark_date = bookmark[replication_key]
             new_bookmark_date = dateutil.parser.parse(bookmark_date) - timedelta(minutes=1)
             bookmark["bookmark_date"] = datetime.strftime(new_bookmark_date, self.BOOKMARK_FORMAT)
 


### PR DESCRIPTION
# Description of change
Writes a bookmark of `now` for incremental streams when no data is synced. This behavior was lost in https://github.com/singer-io/tap-chargebee/pull/113. 

# Manual QA steps
 - Ran the tap locally twice
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
