### PR TITLE
[SAC-30996] - Unauthorized streams exclusion from catalog during discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ singer-check-tap-data
 *.egg-info
 dist/
 __pycache__/
+venv/
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.8.0
-- Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error [#125](https://github.com/singer-io/tap-chargebee/pull/125)
+- Streams that cannot be accessed with the provided credentials (403) are now excluded from the catalog during discovery instead of raising an error [#125](https://github.com/singer-io/tap-chargebee/pull/125)
 
 ## 1.7.1
 - Bump requests library to 2.33.0 #[124](https://github.com/singer-io/tap-chargebee/pull/124)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0
 - Streams that cannot be accessed with the provided credentials (403) are now excluded from the catalog during discovery instead of raising an error [#125](https://github.com/singer-io/tap-chargebee/pull/125)
+- Bump singer-python to 6.8.0 and requests to 2.34.2
 
 ## 1.7.1
 - Bump requests library to 2.33.0 #[124](https://github.com/singer-io/tap-chargebee/pull/124)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.0
+- Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error [#125](https://github.com/singer-io/tap-chargebee/pull/125)
+
 ## 1.7.1
 - Bump requests library to 2.33.0 #[124](https://github.com/singer-io/tap-chargebee/pull/124)
 

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup(name='tap-chargebee',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_chargebee'],
       install_requires=[
-          'singer-python==6.3.0',
+          'singer-python==6.8.0',
           'backoff==2.2.1',
-          'requests==2.33.0'
+          'requests==2.34.2'
       ],
       entry_points='''
           [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-chargebee',
-      version='1.7.1',
+      version='1.8.0',
       description='Singer.io tap for extracting data from the Chargebee API',
       author='dwallace@envoy.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_chargebee/__init__.py
+++ b/tap_chargebee/__init__.py
@@ -2,7 +2,7 @@ import singer
 import sys
 import json
 from singer import metadata, Catalog
-from tap_chargebee.client import ChargebeeClient
+from tap_chargebee.client import ChargebeeClient, ChargebeeForbiddenError
 import tap_chargebee.streams as streams
 
 LOGGER = singer.get_logger()
@@ -58,15 +58,51 @@ def get_available_streams(config: dict, cb_client: ChargebeeClient):
     return available_streams
 
 
-def do_discover(config: dict, state: dict, available_streams: list):
+def _apply_access_checks(
+    config: dict, state: dict, client: ChargebeeClient, available_streams: list
+) -> list:
     """
-    Generate the catalog
+    Probe each stream for read access and return only the accessible stream classes.
+    Logs a warning for each inaccessible stream.
+    Raises ChargebeeForbiddenError if no streams are accessible.
+    """
+    accessible = []
+    inaccessible = []
+
+    for stream_class in available_streams:
+        stream_instance = stream_class(config, state, None, client)
+        if stream_instance.check_access():
+            accessible.append(stream_class)
+        else:
+            inaccessible.append(stream_class.STREAM)
+
+    for stream_name in inaccessible:
+        LOGGER.warning(
+            "Stream '%s' is not accessible with the provided credentials (403). "
+            "Excluding from catalog.",
+            stream_name,
+        )
+
+    if not accessible:
+        raise ChargebeeForbiddenError(
+            "No streams are accessible with the provided credentials. "
+            "Cannot generate catalog."
+        )
+
+    return accessible
+
+
+def do_discover(config: dict, state: dict, available_streams: list, client: ChargebeeClient):
+    """
+    Generate the catalog, excluding any streams that return 403 Forbidden.
     """
     LOGGER.info("Starting discovery.")
+
+    accessible_streams = _apply_access_checks(config, state, client, available_streams)
     catalog = []
 
-    # Generate catalog for each stream based on the product catalog version
-    for available_stream in available_streams:
+    # Generate catalog for each accessible stream
+    for available_stream in accessible_streams:
         stream = available_stream(config, state, None, None)
         catalog += stream.generate_catalog()
 
@@ -113,7 +149,7 @@ def main():
     available_streams = get_available_streams(args.config, client)
 
     if args.discover:
-        do_discover(args.config, args.state, available_streams)
+        do_discover(args.config, args.state, available_streams, client)
     elif args.catalog:
         do_sync(args.config, args.catalog, args.state, client)
 

--- a/tap_chargebee/__init__.py
+++ b/tap_chargebee/__init__.py
@@ -66,30 +66,30 @@ def _apply_access_checks(
     Logs a warning for each inaccessible stream.
     Raises ChargebeeForbiddenError if no streams are accessible.
     """
-    accessible = []
-    inaccessible = []
+    accessible_streams = []
+    inaccessible_streams = []
 
     for stream_class in available_streams:
         stream_instance = stream_class(config, state, None, client)
         if stream_instance.check_access():
-            accessible.append(stream_class)
+            accessible_streams.append(stream_class)
         else:
-            inaccessible.append(stream_class.STREAM)
+            inaccessible_streams.append(stream_class.STREAM)
 
-    for stream_name in inaccessible:
+    for stream_name in inaccessible_streams:
         LOGGER.warning(
             "Stream '%s' is not accessible with the provided credentials (403). "
             "Excluding from catalog.",
             stream_name,
         )
 
-    if not accessible:
+    if not accessible_streams:
         raise ChargebeeForbiddenError(
             "No streams are accessible with the provided credentials. "
             "Cannot generate catalog."
         )
 
-    return accessible
+    return accessible_streams
 
 
 def do_discover(config: dict, state: dict, available_streams: list, client: ChargebeeClient):

--- a/tap_chargebee/client.py
+++ b/tap_chargebee/client.py
@@ -201,6 +201,21 @@ class ChargebeeClient:
             LOGGER.error("Request failed: %s", str(e))
             raise
 
+    def check_access(self, url: str, method: str) -> bool:
+        """
+        Check whether a stream endpoint is accessible without triggering backoff retries.
+        Returns True if the response is not a 403 Forbidden, False otherwise.
+        """
+        response = requests.request(
+            method,
+            url,
+            auth=(self.config.get("api_key"), ""),
+            headers=self.get_headers(),
+            params={"limit": 1},
+            timeout=self.request_timeout,
+        )
+        return response.status_code != 403
+
     def get_offset_based_pages(
         self,
         url: str,

--- a/tap_chargebee/client.py
+++ b/tap_chargebee/client.py
@@ -204,7 +204,9 @@ class ChargebeeClient:
     def check_access(self, url: str, method: str) -> bool:
         """
         Check whether a stream endpoint is accessible without triggering backoff retries.
-        Returns True if the response is not a 403 Forbidden, False otherwise.
+        Returns True if the endpoint is accessible (200), False if 403 Forbidden.
+        Raises typed exceptions for all other non-200 responses (e.g. 401, 5xx)
+        so that discovery fails fast on bad credentials or server errors.
         """
         response = requests.request(
             method,
@@ -214,7 +216,10 @@ class ChargebeeClient:
             params={"limit": 1},
             timeout=self.request_timeout,
         )
-        return response.status_code != 403
+        if response.status_code == 403:
+            return False
+        raise_for_error(response)
+        return True
 
     def get_offset_based_pages(
         self,

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -169,6 +169,13 @@ class BaseChargebeeStream:
             }
         ]
 
+    def check_access(self) -> bool:
+        """
+        Returns True if the stream endpoint is accessible with the provided credentials.
+        Returns False if a 403 Forbidden response is received.
+        """
+        return self.client.check_access(self.get_url(), self.API_METHOD)
+
     def update_bookmark(self, bookmark_value: str):
         """
         Updates the bookmark in the state if the new bookmark value is greater than the current one.

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -106,8 +106,8 @@ class TestApplyAccessChecks(unittest.TestCase):
         self.assertEqual(result, [CommentsStream, CustomersStream])
 
     def test_forbidden_stream_is_excluded(self):
-        # Simulate comments endpoint being forbidden/inaccessible
-        self.mock_client.check_access.side_effect = lambda url, method: "comments" not in url
+        # Deny access to the comments stream based on its canonical stream name
+        self.mock_client.check_access.side_effect = lambda url, method: CommentsStream.STREAM not in url
         result = _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
         self.assertEqual(result, [CustomersStream])
 
@@ -118,8 +118,8 @@ class TestApplyAccessChecks(unittest.TestCase):
 
     @patch("tap_chargebee.LOGGER")
     def test_warning_logged_for_excluded_stream(self, mock_logger):
-        # Simulate comments endpoint being forbidden/inaccessible
-        self.mock_client.check_access.side_effect = lambda url, method: "comments" not in url
+        # Deny access to the comments stream based on its canonical stream name
+        self.mock_client.check_access.side_effect = lambda url, method: CommentsStream.STREAM not in url
         _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
         mock_logger.warning.assert_called_once()
-        self.assertEqual("comments", mock_logger.warning.call_args[0][1])
+        self.assertEqual(CommentsStream.STREAM, mock_logger.warning.call_args[0][1])

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -106,9 +106,10 @@ class TestApplyAccessChecks(unittest.TestCase):
         self.assertEqual(result, [CommentsStream, CustomersStream])
 
     def test_forbidden_stream_is_excluded(self):
-        self.mock_client.check_access.side_effect = lambda url, method: "comments" in url
+        # Simulate comments endpoint being forbidden/inaccessible
+        self.mock_client.check_access.side_effect = lambda url, method: "comments" not in url
         result = _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
-        self.assertEqual(result, [CommentsStream])
+        self.assertEqual(result, [CustomersStream])
 
     def test_all_inaccessible_raises_forbidden_error(self):
         self.mock_client.check_access.return_value = False
@@ -117,7 +118,8 @@ class TestApplyAccessChecks(unittest.TestCase):
 
     @patch("tap_chargebee.LOGGER")
     def test_warning_logged_for_excluded_stream(self, mock_logger):
-        self.mock_client.check_access.side_effect = lambda url, method: "comments" in url
+        # Simulate comments endpoint being forbidden/inaccessible
+        self.mock_client.check_access.side_effect = lambda url, method: "comments" not in url
         _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
         mock_logger.warning.assert_called_once()
-        self.assertIn("customers", mock_logger.warning.call_args[0][1])
+        self.assertEqual("comments", mock_logger.warning.call_args[0][1])

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,6 +1,9 @@
 import unittest
 from unittest.mock import patch, MagicMock, mock_open
 from tap_chargebee.streams.comments import CommentsStream
+from tap_chargebee.streams.customers import CustomersStream
+from tap_chargebee import _apply_access_checks
+from tap_chargebee.client import ChargebeeClient, ChargebeeForbiddenError
 
 
 class TestLoadSharedSchemaMethods(unittest.TestCase):
@@ -83,3 +86,38 @@ class TestLoadSharedSchemaMethods(unittest.TestCase):
         self.assertEqual(
             result, {"schema1.json": {"key": "value"}, "schema1.json": {"key": "value"}}
         )
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            "start_date": "2017-01-01T00:00:00Z",
+            "include_deleted": "false",
+            "site": "test-site",
+            "api_key": "test-key",
+            "item_model": False,
+        }
+        self.mock_client = MagicMock(spec=ChargebeeClient)
+
+    def test_all_accessible_returns_all_streams(self):
+        self.mock_client.check_access.return_value = True
+        result = _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
+        self.assertEqual(result, [CommentsStream, CustomersStream])
+
+    def test_forbidden_stream_is_excluded(self):
+        self.mock_client.check_access.side_effect = lambda url, method: "comments" in url
+        result = _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
+        self.assertEqual(result, [CommentsStream])
+
+    def test_all_inaccessible_raises_forbidden_error(self):
+        self.mock_client.check_access.return_value = False
+        with self.assertRaises(ChargebeeForbiddenError):
+            _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
+
+    @patch("tap_chargebee.LOGGER")
+    def test_warning_logged_for_excluded_stream(self, mock_logger):
+        self.mock_client.check_access.side_effect = lambda url, method: "comments" in url
+        _apply_access_checks(self.config, {}, self.mock_client, [CommentsStream, CustomersStream])
+        mock_logger.warning.assert_called_once()
+        self.assertIn("customers", mock_logger.warning.call_args[0][1])


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-30996
- Exclude unauthorized streams from catalog during discovery  


# Manual QA steps
 - [ ]  Discovery: Creds unavailable
 - [ ]  Sync: Creds unavailable
 - [x]  Unit Tests: Passes
 - [x]  Integration test: Passes
 
# Rollback steps
 - revert this branch